### PR TITLE
Expose extensions option

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Options:
   -h, --help       Displays these instructions.
   -o, --output     Output path of the bundle. Defaults to stdout.
   -t, --transform  Browserify transform stream(s) to use.
+  --extension      Consider files with specified EXTENSION as modules, this option can used multiple times.
   -O, --open       Open the file immediately.
+  -n, --noparse    Omit file from parse.
 ```
 
 Simply specify your script entry points as you would when building a project
@@ -60,7 +62,7 @@ discify index.js --open
 
 ## Module API ##
 
-### `require('disc').json(files, transforms, callback)` ###
+### `require('disc').json(files, transforms, extensions, callback)` ###
 
 Takes an array of files, and an array of browserify transform streams,
 and gathers the required data - calling `callback(err, json)` with either an
@@ -74,4 +76,6 @@ following options to the function to modify the output:
 * `files`: the files to parse/traverse
 * `footer`: HTML to include below the chart.
 * `transforms`: transform streams to pass to
+  [module-deps](http://ghub.io/module-deps).
+* `extensions`: extensions to pass to
   [module-deps](http://ghub.io/module-deps).

--- a/bin/discify
+++ b/bin/discify
@@ -18,6 +18,8 @@ var argv = optimist
   .alias('t', 'transform')
   .describe('t', 'Browserify transform stream(s) to use.')
 
+  .describe('extension', 'Consider files with specified EXTENSION as modules, this option can used multiple times.')
+
   .alias('O', 'open')
   .describe('O', 'Open the file immediately.')
 
@@ -44,6 +46,7 @@ if (!files.length || argv.help) {
 disc.bundle({
     files: files
   , transforms: argv.transform || []
+  , extensions: argv.extension || []
   , noparse: argv.noparse || []
 }, function(err, html) {
   if (err) throw err

--- a/index.js
+++ b/index.js
@@ -27,13 +27,14 @@ var ignore = Object.keys(builtins).concat(['os', 'module', 'cluster'])
 ignore = '^(?:' + ignore.join('|') + ')$'
 ignore = new RegExp(ignore, 'i')
 
-function json(files, transforms, noparse, callback) {
+function json(files, transforms, extensions, noparse, callback) {
   var found = []
     , foundbuiltins = []
     , virtual = []
 
   files = toarray(files)
   transforms = toarray(transforms)
+  extensions = toarray(extensions)
   noparse = toarray(noparse)
   callback = once(callback)
 
@@ -43,6 +44,7 @@ function json(files, transforms, noparse, callback) {
 
   mdeps(files, {
       transform: transforms
+    , extensions: [".js", ".json"].concat(extensions)
     , noParse: noparse
     , filter: function(module) {
       if (builtins[module]) {
@@ -107,10 +109,11 @@ function bundle(opts, callback) {
   var files = toarray(opts.files || null)
   var noparse = toarray(opts.noparse || null)
   var transforms = toarray(opts.transforms || null)
+  var extensions = toarray(opts.extensions || null)
   var footer = opts.footer || ''
   var button = opts.button || ''
 
-  json(files, transforms, noparse, function(err, data) {
+  json(files, transforms, extensions, noparse, function(err, data) {
     if (err) return callback(err)
 
     data = '<script type="text/javascript">'


### PR DESCRIPTION
I use the `--extension` option in Browserify to require `.jsx` files and disc needed a way to pass that along to module-deps.

I also changed `opts.transform` to be `opts.transforms` to be consistent and to match the existing docs.
