### PR TITLE
Move opener to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,12 +34,12 @@
     "file-tree": "0.0.0",
     "builtins": "0.0.3",
     "through": "^2.3.4",
-    "duplexer": "^0.1.1"
+    "duplexer": "^0.1.1",
+    "opener": "^1.3.0"
   },
   "devDependencies": {
     "btoa": "^1.1.1",
     "marked": "^0.3.2",
-    "opener": "^1.3.0",
     "browserify": "^3.33.0",
     "clean-css": "^2.1.6",
     "rework": "^0.20.2",


### PR DESCRIPTION
Calling discify after installing with `npm install disc -g` fails unless the "opener" dependency has already been installed globally. Moving it from `devDependencies` to to `dependencies` fixes it.
