### PR TITLE
Add tests

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,8 +58,10 @@ function json(bundles, callback) {
   })
 
   modules = modules.filter(function(module) {
-    return !isEmpty(module)
+    return module && !isEmpty(module)
   })
+
+  if (!modules.length) return
 
   var browserifyModules = modules.filter(fromBrowserify(true))
   var otherModules = modules.filter(function(module) {

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "prepublish": "mkdir -p build && npm run browserify && npm run rework && npm run bundle-demo",
     "browserify": "browserify src/index.js | uglifyjs -c 2> /dev/null > build/bundle.js",
     "bundle-demo": "node lib/bundle-demo > index.html",
+    "build-fixture": "browserify --full-paths ./test/fixture/index.js > ./test/fixture/bundle.js && browserify ./test/fixture/index.js > ./test/fixture/bundle-no-full.js",
     "demo": "npm run prepublish && opener index.html",
     "rework": "node lib/bundle-css > build/style.css"
   },
@@ -46,6 +47,7 @@
     "marked": "^0.3.2",
     "prettysize": "0.0.3",
     "rework": "^0.20.2",
+    "tape": "^3.0.3",
     "uglify-js": "^2.4.15"
   },
   "keywords": [

--- a/test/fixture/bundle-no-full.js
+++ b/test/fixture/bundle-no-full.js
@@ -1,0 +1,4 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
+module.exports = 42
+
+},{}]},{},[1])

--- a/test/fixture/bundle.js
+++ b/test/fixture/bundle.js
@@ -1,0 +1,4 @@
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({"/Users/tmcw/src/disc/test/fixture/index.js":[function(require,module,exports){
+module.exports = 42
+
+},{}]},{},["/Users/tmcw/src/disc/test/fixture/index.js"])

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -1,0 +1,1 @@
+module.exports = 42

--- a/test/json.js
+++ b/test/json.js
@@ -1,0 +1,21 @@
+var json = require('../').json
+var test = require('tape')
+var fs = require('fs')
+
+test('json', function(t) {
+    json([fs.readFileSync(__dirname + '/fixture/bundle.js', 'utf8')], function(err, res) {
+        t.notOk(err)
+        t.ok(res)
+        t.equal(res.name, 'index.js', 'main file name')
+        t.equal(res.children.length, 1, '.children.length')
+        t.end()
+    })
+})
+
+test('json missing --full-paths', function(t) {
+    json([fs.readFileSync(__dirname + '/fixture/bundle-no-full.js', 'utf8')], function(err, res) {
+        t.ok(err, 'returns error')
+        t.notOk(res, 'does not return result')
+        t.end()
+    })
+})


### PR DESCRIPTION
This also caught a minor bug around error handling: this is masked
by the bin, which throws as soon as the callback returns an error,
but using .json programmatically will trigger a bug in which the
function continues and tries to process the return value of the callback
as a module.
