### PR TITLE
Remove protocol

### DIFF
--- a/src/base.html
+++ b/src/base.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html><head>
   <meta charset="utf-8">
-  <link href='http://fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400|Source+Code+Pro:300,500' rel='stylesheet' type='text/css'>
+  <link href='//fonts.googleapis.com/css?family=Source+Sans+Pro:200,300,400|Source+Code+Pro:300,500' rel='stylesheet' type='text/css'>
   <style><!-- @@styles --></style>
 </head><body>
   <!-- @@header -->


### PR DESCRIPTION
This PR removes the direct reference to `http://` in the template. It's not necessary, and it causes the browser to complain when disc is loaded over https.