### PR TITLE
Listen on random port rather than 12999

### DIFF
--- a/bin/discify
+++ b/bin/discify
@@ -78,9 +78,9 @@ function handle(bundles) {
 
       res.setHeader('content-type', 'text/html')
       res.end(html)
-    }).listen(12999, function(err) {
+    }).listen(function(err) {
       if (err) throw err
-      open('http://localhost:12999/')
+      open('http://localhost:' + server.address().port + '/')
     })
   })
 }


### PR DESCRIPTION
The current `bin/discify` script listens on port 12999 - this may cause a conflict if something is already listening on that port. The `http` module can create a server on a random available port instead.