### PR TITLE
Support ES2015 parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "readmeFilename": "README.md",
   "dependencies": {
     "bl": "^0.7.0",
-    "browser-unpack": "^0.2.3",
+    "browser-unpack": "^1.1.1",
     "builtins": "0.0.3",
     "commondir": "0.0.1",
     "d3": "^3.4.3",


### PR DESCRIPTION
Update browser unpack, which now uses acorn over esprima-fb
`browser-unpack` was indeed bringing a really old (in JS-years) JS parser to the party. Newer versions of the dependency bring newer parsers, which now works for me (using some amount of ES2015 in my files).

Fixes https://github.com/hughsk/disc/issues/51
