### PR TITLE
Handle module.id being null

### DIFF
--- a/index.js
+++ b/index.js
@@ -255,7 +255,7 @@ function values(object) {
 }
 
 function isEmpty(module) {
-  return (
+  return module.id === undefined || (
     path.basename(module.id) === '_empty.js' &&
   (!fs.existsSync(module.id) || !fs.statSync(module.id).size)
   )


### PR DESCRIPTION
Fixes error "TypeError: Path must be a string. Received undefined" when
operating on minified output that had been processed by derequire, e.g.

    {
      id: undefined,
      source: '"use strict";var Promise=_dereq_("./promise.js")();module.exports=Promise',
      deps: {
        './promise.js': '/Users/username/src/myproject/core/node_modules/bluebird/js/main/promise.js'
      }
    }