### PR TITLE
fix deprecation warning: remove 'flatten' package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,7 +1,6 @@
 var unpack = require('browser-unpack')
 var builtins = require('builtins')
 var through = require('through')
-var flatten = require('flatten')
 var duplex = require('duplexer')
 var pluck = require('plucker')
 var uniq = require('uniq')
@@ -17,6 +16,16 @@ var versions = require('./lib/versions')
 module.exports = createStream
 createStream.json = json
 createStream.bundle = bundle
+
+// TODO: When Node 10 support is dropped, replace this with Array.prototype.flat
+function flat (arr1) {
+  return arr1.reduce(
+    (acc, val) => Array.isArray(val)
+      ? acc.concat(flat(val))
+      : acc.concat(val),
+    []
+  )
+}
 
 function createStream(opts) {
   opts = opts || {}
@@ -39,7 +48,7 @@ function createStream(opts) {
 }
 
 function json(bundles, callback) {
-  var modules = flatten(bundles
+  var modules = flat(bundles
     .map(String)
     .map(unpack)
   ).map(function(module) {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "d3": "^3.4.3",
     "duplexer": "^0.1.1",
     "file-tree": "^1.0.0",
-    "flatten": "0.0.1",
     "map-async": "^0.1.1",
     "opener": "^1.3.0",
     "optimist": "^0.6.1",


### PR DESCRIPTION
Simple change to fix the deprecation warning.

Also – if ya'll need help maintaining this package, feel free to add me and I'll do what I can 👍 