### PR TITLE
Remove sudo from Installation-instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ make sure you have [node](http://nodejs.org/) installed on your machine first.
 Installing should then be as easy as:
 
 ``` bash
-sudo npm install -g disc
+npm install -g disc
 ```
 
 ## Command-Line Interface ##


### PR DESCRIPTION
There should be no reason to ever use sudo to install a global npm package. If sudo is needed, file permissions are messed up on the machine.

Further, if people blindly copy-paste the command from this repo, there's a chance it'll mess up their file permissions even if they weren't already.